### PR TITLE
Upgrade PHPStan to be 1.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "monolog/monolog": "^2.3",
         "overtrue/phplint": "^3",
         "php-di/php-di": "^6.3",
-        "phpstan/phpstan": "0.*",
+        "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8 || ^9",
         "squizlabs/php_codesniffer": "^3",
         "symfony/mailer": "^5.3"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,7 @@ parameters:
 	paths:
 		- src
 		- tests
+	ignoreErrors:
+		- '#Cannot call method getListeners\(\) on mixed.#'
+		- '#Cannot call method send\(\) on mixed.#'
+		- '#Parameter \#1 \$transport of class Symfony\\Component\\Mailer\\Mailer constructor expects Symfony\\Component\\Mailer\\Transport\\TransportInterface, mixed given.#'


### PR DESCRIPTION
# Changed log

- Upgrading the PHPStan to be `1.x` version.
- Ignoring some messages when using the `PHPStan 1.x` version to do static code analysis.