### PR TITLE
Drop PHP-7.2 and PHP-7.3 version supports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0' ]
+        php-versions: [ '8.0', '8.1' ]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:
@@ -34,13 +34,8 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Install dependencies for PHP 7
-        if: matrix.php-versions < '8.0'
+      - name: Install dependencies for PHP
         run: composer update --prefer-dist --no-progress
-
-      - name: Install dependencies for PHP 8
-        if: matrix.php-versions >= '8.0'
-        run: composer update --prefer-dist --no-progress --ignore-platform-req=php
 
       - name: Run test suite
         run: composer test:all

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of PHPUnit test traits.
 
 ## Requirements
 
-* PHP 7.2+ or 8.0+
+* PHP 8.0+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "homepage": "https://github.com/selective-php/test-traits",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",

--- a/src/Traits/ContainerTestTrait.php
+++ b/src/Traits/ContainerTestTrait.php
@@ -2,9 +2,7 @@
 
 namespace Selective\TestTrait\Traits;
 
-use BadMethodCallException;
 use Psr\Container\ContainerInterface;
-use UnexpectedValueException;
 
 /**
  * Container Test Trait.
@@ -23,7 +21,7 @@ trait ContainerTestTrait
      *
      * @param ContainerInterface|null $container The container
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      *
      * @return void
      */
@@ -35,7 +33,7 @@ trait ContainerTestTrait
             return;
         }
 
-        throw new UnexpectedValueException('Container must be initialized');
+        throw new \UnexpectedValueException('Container must be initialized');
     }
 
     /**
@@ -44,7 +42,7 @@ trait ContainerTestTrait
      * @param string $name The entry name
      * @param mixed $value The value
      *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      *
      * @return void
      */
@@ -56,6 +54,6 @@ trait ContainerTestTrait
             return;
         }
 
-        throw new BadMethodCallException('This DI container does not support this feature');
+        throw new \BadMethodCallException('This DI container does not support this feature');
     }
 }

--- a/src/Traits/DatabaseTestTrait.php
+++ b/src/Traits/DatabaseTestTrait.php
@@ -2,10 +2,7 @@
 
 namespace Selective\TestTrait\Traits;
 
-use DomainException;
 use PDO;
-use PDOStatement;
-use UnexpectedValueException;
 
 /**
  * Database test.
@@ -45,11 +42,11 @@ trait DatabaseTestTrait
     /**
      * Get database connection.
      *
-     * @return PDO The PDO instance
+     * @return \PDO The PDO instance
      */
-    protected function getConnection(): PDO
+    protected function getConnection(): \PDO
     {
-        return $this->container->get(PDO::class);
+        return $this->container->get(\PDO::class);
     }
 
     /**
@@ -80,10 +77,10 @@ trait DatabaseTestTrait
     {
         $statement = $this->getConnection()->prepare('SHOW VARIABLES LIKE ?');
         if (!$statement || $statement->execute([$variable]) === false) {
-            throw new UnexpectedValueException('Invalid SQL statement');
+            throw new \UnexpectedValueException('Invalid SQL statement');
         }
 
-        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
 
         if ($row === false) {
             // Database variable not defined
@@ -110,7 +107,7 @@ trait DatabaseTestTrait
                 WHERE table_schema = database()'
         );
 
-        $rows = (array)$statement->fetchAll(PDO::FETCH_ASSOC);
+        $rows = (array)$statement->fetchAll(\PDO::FETCH_ASSOC);
 
         $sql = [];
         foreach ($rows as $row) {
@@ -129,16 +126,16 @@ trait DatabaseTestTrait
      *
      * @param string $sql The sql
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      *
-     * @return PDOStatement The statement
+     * @return \PDOStatement The statement
      */
-    private function createQueryStatement(string $sql): PDOStatement
+    private function createQueryStatement(string $sql): \PDOStatement
     {
-        $statement = $this->getConnection()->query($sql, PDO::FETCH_ASSOC);
+        $statement = $this->getConnection()->query($sql, \PDO::FETCH_ASSOC);
 
-        if (!$statement instanceof PDOStatement) {
-            throw new UnexpectedValueException('Invalid SQL statement');
+        if (!$statement instanceof \PDOStatement) {
+            throw new \UnexpectedValueException('Invalid SQL statement');
         }
 
         return $statement;
@@ -147,18 +144,18 @@ trait DatabaseTestTrait
     /**
      * Import table schema.
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      *
      * @return void
      */
     protected function importSchema(): void
     {
         if (!$this->schemaFile) {
-            throw new UnexpectedValueException('The path for schema.sql is not defined');
+            throw new \UnexpectedValueException('The path for schema.sql is not defined');
         }
 
         if (!file_exists($this->schemaFile)) {
-            throw new UnexpectedValueException(sprintf('File not found: %s', $this->schemaFile));
+            throw new \UnexpectedValueException(sprintf('File not found: %s', $this->schemaFile));
         }
 
         $pdo = $this->getConnection();
@@ -197,7 +194,7 @@ trait DatabaseTestTrait
             );
         }
 
-        $rows = (array)$statement->fetchAll(PDO::FETCH_ASSOC);
+        $rows = (array)$statement->fetchAll(\PDO::FETCH_ASSOC);
 
         $sql = [];
         foreach ($rows as $row) {
@@ -257,16 +254,16 @@ trait DatabaseTestTrait
      *
      * @param string $sql The sql
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      *
-     * @return PDOStatement The statement
+     * @return \PDOStatement The statement
      */
-    private function createPreparedStatement(string $sql): PDOStatement
+    private function createPreparedStatement(string $sql): \PDOStatement
     {
         $statement = $this->getConnection()->prepare($sql);
 
-        if (!$statement instanceof PDOStatement) {
-            throw new UnexpectedValueException('Invalid SQL statement');
+        if (!$statement instanceof \PDOStatement) {
+            throw new \UnexpectedValueException('Invalid SQL statement');
         }
 
         return $statement;
@@ -304,7 +301,7 @@ trait DatabaseTestTrait
      * @param int $id The primary key value
      * @param array|null $fields The array of fields
      *
-     * @throws DomainException
+     * @throws \DomainException
      *
      * @return array Row
      */
@@ -314,10 +311,10 @@ trait DatabaseTestTrait
         $statement = $this->createPreparedStatement($sql);
         $statement->execute(['id' => $id]);
 
-        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
 
         if (empty($row)) {
-            throw new DomainException(sprintf('Row not found: %s', $id));
+            throw new \DomainException(sprintf('Row not found: %s', $id));
         }
 
         if ($fields) {
@@ -399,7 +396,7 @@ trait DatabaseTestTrait
     {
         $sql = sprintf('SELECT COUNT(*) AS counter FROM `%s`;', $table);
         $statement = $this->createQueryStatement($sql);
-        $row = $statement->fetch(PDO::FETCH_ASSOC) ?: [];
+        $row = $statement->fetch(\PDO::FETCH_ASSOC) ?: [];
 
         return (int)($row['counter'] ?? 0);
     }
@@ -432,7 +429,7 @@ trait DatabaseTestTrait
         $statement = $this->createPreparedStatement($sql);
         $statement->execute(['id' => $id]);
 
-        return $statement->fetch(PDO::FETCH_ASSOC) ?: [];
+        return $statement->fetch(\PDO::FETCH_ASSOC) ?: [];
     }
 
     /**

--- a/src/Traits/HttpTestTrait.php
+++ b/src/Traits/HttpTestTrait.php
@@ -8,7 +8,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
-use RuntimeException;
 
 /**
  * HTTP Test Trait.
@@ -22,14 +21,14 @@ trait HttpTestTrait
      * @param string|UriInterface $uri The URI
      * @param array $serverParams The server parameters
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ServerRequestInterface The request
      */
     protected function createRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface
     {
         if (!$this->container instanceof ContainerInterface) {
-            throw new RuntimeException('DI container not found');
+            throw new \RuntimeException('DI container not found');
         }
 
         $factory = $this->container->get(ServerRequestFactoryInterface::class);
@@ -63,14 +62,14 @@ trait HttpTestTrait
      * @param int $code HTTP status code; defaults to 200
      * @param string $reasonPhrase Reason phrase to associate with status code
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      *
      * @return ResponseInterface The response
      */
     protected function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
     {
         if (!$this->container instanceof ContainerInterface) {
-            throw new RuntimeException('DI container not found');
+            throw new \RuntimeException('DI container not found');
         }
 
         $factory = $this->container->get(ResponseFactoryInterface::class);

--- a/src/Traits/MailerTestTrait.php
+++ b/src/Traits/MailerTestTrait.php
@@ -3,7 +3,6 @@
 namespace Selective\TestTrait\Traits;
 
 use PHPUnit\Framework\Constraint\LogicalNot;
-use RuntimeException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
@@ -18,7 +17,6 @@ use Symfony\Component\Mime\Test\Constraint\EmailHasHeader;
 use Symfony\Component\Mime\Test\Constraint\EmailHeaderSame;
 use Symfony\Component\Mime\Test\Constraint\EmailHtmlBodyContains;
 use Symfony\Component\Mime\Test\Constraint\EmailTextBodyContains;
-use UnexpectedValueException;
 
 /**
  * Array Test Trait.
@@ -150,7 +148,7 @@ trait MailerTestTrait
         $message = $this->findMailerMessage($index, $transport);
 
         if ($message === null) {
-            throw new UnexpectedValueException('The Mailer message was not found.');
+            throw new \UnexpectedValueException('The Mailer message was not found.');
         }
 
         return $message;
@@ -175,6 +173,6 @@ trait MailerTestTrait
             }
         }
 
-        throw new RuntimeException('The Mailer event dispatcher must be enabled to make email assertions.');
+        throw new \RuntimeException('The Mailer event dispatcher must be enabled to make email assertions.');
     }
 }

--- a/src/Traits/MockTestTrait.php
+++ b/src/Traits/MockTestTrait.php
@@ -2,7 +2,6 @@
 
 namespace Selective\TestTrait\Traits;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 
@@ -16,14 +15,14 @@ trait MockTestTrait
      *
      * @param string $class The class or interface
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      *
      * @return MockObject The mock
      */
     protected function mock(string $class): MockObject
     {
         if (!class_exists($class)) {
-            throw new InvalidArgumentException(sprintf('Class not found: %s', $class));
+            throw new \InvalidArgumentException(sprintf('Class not found: %s', $class));
         }
 
         $mock = $this->getMockBuilder($class)


### PR DESCRIPTION
# Changed log

- According to the [official PHP website](https://www.php.net/eol.php), it's time to drop the `PHP 7.2` and `PHP 7.3` versions.
- Letting the PHP package require `PHP 7.4` and `PHP 8.0+` versions.