### PR TITLE
Removed nyholm/psr7 warning

### DIFF
--- a/src/Traits/RouteTestTrait.php
+++ b/src/Traits/RouteTestTrait.php
@@ -15,9 +15,6 @@ trait RouteTestTrait
      * @param string $routeName Route name
      * @param string[] $data Named argument replacement data
      * @param string[] $queryParams Optional query string parameters.
-     * If you're using `nyholm/psr7`, query parameters MUST be added via
-     * `$request = $request->withQueryParams($queryParams)`
-     * to be retrieved with `$request->getQueryParams();`
      *
      * @return string The route with base path
      */

--- a/src/Traits/RouteTestTrait.php
+++ b/src/Traits/RouteTestTrait.php
@@ -14,7 +14,7 @@ trait RouteTestTrait
      *
      * @param string $routeName Route name
      * @param string[] $data Named argument replacement data
-     * @param string[] $queryParams Optional query string parameters.
+     * @param string[] $queryParams Optional query string parameters
      *
      * @return string The route with base path
      */

--- a/src/Traits/RouteTestTrait.php
+++ b/src/Traits/RouteTestTrait.php
@@ -13,8 +13,8 @@ trait RouteTestTrait
      * Build the path for a named route including the base path.
      *
      * @param string $routeName Route name
-     * @param string[] $data Named argument replacement data
-     * @param string[] $queryParams Optional query string parameters
+     * @param array<string, string> $data Named argument replacement data
+     * @param array<string, string> $queryParams Optional query string parameters
      *
      * @return string The route with base path
      */


### PR DESCRIPTION
It seems that query string parameters passed via arguments [finally work](https://github.com/Nyholm/psr7/pull/214) with nyholm/psr7.

