### PR TITLE
Refactor method signatures to use nullable parameter syntax

### DIFF
--- a/src/Traits/DatabaseSchemaTestTrait.php
+++ b/src/Traits/DatabaseSchemaTestTrait.php
@@ -22,7 +22,7 @@ trait DatabaseSchemaTestTrait
      *
      * @return void
      */
-    protected function setUpDatabase(string $schemaFile = null): void
+    protected function setUpDatabase(?string $schemaFile = null): void
     {
         if (isset($schemaFile)) {
             $this->schemaFile = $schemaFile;

--- a/src/Traits/DatabaseTableTestTrait.php
+++ b/src/Traits/DatabaseTableTestTrait.php
@@ -46,7 +46,7 @@ trait DatabaseTableTestTrait
      *
      * @return array Row
      */
-    protected function getTableRowById(string $table, int $id, array $fields = null): array
+    protected function getTableRowById(string $table, int $id, ?array $fields = null): array
     {
         $sql = sprintf('SELECT * FROM `%s` WHERE `id` = :id', $table);
         $statement = $this->createPreparedStatement($sql);

--- a/src/Traits/HttpJsonTestTrait.php
+++ b/src/Traits/HttpJsonTestTrait.php
@@ -22,7 +22,7 @@ trait HttpJsonTestTrait
      *
      * @return ServerRequestInterface
      */
-    protected function createJsonRequest(string $method, $uri, array $data = null): ServerRequestInterface
+    protected function createJsonRequest(string $method, $uri, ?array $data = null): ServerRequestInterface
     {
         $request = $this->createRequest($method, $uri);
 

--- a/src/Traits/HttpTestTrait.php
+++ b/src/Traits/HttpTestTrait.php
@@ -46,7 +46,7 @@ trait HttpTestTrait
      *
      * @return ServerRequestInterface The request
      */
-    protected function createFormRequest(string $method, $uri, array $data = null): ServerRequestInterface
+    protected function createFormRequest(string $method, $uri, ?array $data = null): ServerRequestInterface
     {
         $request = $this->createRequest($method, $uri);
 


### PR DESCRIPTION
Updated method signatures in test traits to explicitly use nullable types (`?type`) for better consistency and clarity. This ensures type hints properly reflect parameters that can accept `null` as a valid value.